### PR TITLE
Unlock DWT register

### DIFF
--- a/libs/trace/include/orbcode/trace/dwt.h
+++ b/libs/trace/include/orbcode/trace/dwt.h
@@ -197,6 +197,7 @@ extern "C"
     void DWTSetup(const DWTOptions* options)
     {
         CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk; // Enable ITM and DWT
+        DWT->LAR = 0xC5ACCE55;                          // Unlock DWT access via magic number
 
         uint32_t ctrl = 0;
         ctrl |= (options->FoldedInstructionCounterEvent ? 1 : 0) << DWT_CTRL_FOLDEVTENA_Pos;


### PR DESCRIPTION
The `DWTSetup` function is currently missing a write to the software lock access register similar to how it is already present in `ITMSetup`.
This locking mechanism may not be enforced on all cores, but on an STM32F746ZG I cannot write to the DWT control register without unlocking it first.